### PR TITLE
requests removed from botocore.vendored

### DIFF
--- a/amazon_lex_bot_deploy/amazon_lex_bot_deploy.py
+++ b/amazon_lex_bot_deploy/amazon_lex_bot_deploy.py
@@ -7,7 +7,7 @@ import io
 import re
 import botocore
 import os
-from botocore.vendored import requests
+import requests
 from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
 
 DEFAULT_REGION = 'us-east-1'

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ if sys.argv[-1] == 'publish':
     os.system('twine upload dist/*')
     sys.exit()
 
-requirements = ['boto3', 'botocore', 'tenacity']
+requirements = ['boto3', 'botocore', 'requests', 'tenacity']
 
 setup_requirements = [ ]
 


### PR DESCRIPTION
*PR to resolve Issue #5*

*Description of changes:*
As per [blog](https://aws.amazon.com/blogs/developer/removing-the-vendored-version-of-requests-from-botocore/) post.  Vendored version of requests has been removed from botocore.  This PR switches to using the standalone python library of [requests](https://requests.readthedocs.io/en/master/).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
